### PR TITLE
Fix missing dependency of saft/saft-store

### DIFF
--- a/src/Saft/Store/composer.json
+++ b/src/Saft/Store/composer.json
@@ -26,7 +26,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "saft/saft-rdf": ">=0.4"
+        "saft/saft-rdf": ">=0.4",
+        "saft/saft-sparql": ">=0.4"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8"


### PR DESCRIPTION
Add saft/saft-sparql as a dependency, since classes within
saft/saft-store make use of it.
