### PR TITLE
Fix a bug related to the extractTriplePattern method in the SPARQL package

### DIFF
--- a/src/Saft/Sparql/Query/AbstractQuery.php
+++ b/src/Saft/Sparql/Query/AbstractQuery.php
@@ -582,7 +582,7 @@ abstract class AbstractQuery implements Query
              * Subject part
              */
             '(' .
-            '\<[a-z0-9\.\/\:#\-]+\>|' . // e.g. <http://foobar/a>
+            '\<[a-z0-9\.\/\:#\-_]+\>|' . // e.g. <http://foobar/a>
             '\?[a-z0-9\_]+|' .          // e.g. ?s
             '[a-z0-9]+\:[a-z0-9]+|' .   // e.g. rdfs:label
             '_:[a-z0-9]+' .             // e.g. _:foo
@@ -591,7 +591,7 @@ abstract class AbstractQuery implements Query
              * Predicate part
              */
             '(' .
-            '\<[a-z0-9\.\/\:#\-]+\>|' . // e.g. <http://foobar/a>
+            '\<[a-z0-9\.\/\:#\-_]+\>|' . // e.g. <http://foobar/a>
             '\?[a-z0-9\_]+|' .          // e.g. ?s
             '[a-z0-9]+\:[a-z0-9]+' .    // e.g. rdfs:label
             ')\s*' .
@@ -599,7 +599,7 @@ abstract class AbstractQuery implements Query
              * Object part
              */
             '(' .
-            '\<[a-zA-Z0-9\.\/\:#\-]+\>|' .            // e.g. <http://foobar/a>
+            '\<[a-zA-Z0-9\.\/\:#\-_]+\>|' .            // e.g. <http://foobar/a>
             '[a-z0-9]+\:[a-z0-9]+|' .                 // e.g. rdfs:label
             '\?[a-z0-9\_]+|' .                        // e.g. ?s
             '\".*\"[\s|\.|\}]|' .                     // e.g. "Foo"

--- a/src/Saft/Sparql/Test/Query/AbstractQueryUnitTest.php
+++ b/src/Saft/Sparql/Test/Query/AbstractQueryUnitTest.php
@@ -559,6 +559,29 @@ class AbstractQueryUnitTest extends TestCase
         );
     }
 
+    public function testExtractTriplePatternUrisWithUnderscore()
+    {
+        $this->assertEquals(
+            array(
+                array(
+                    's' => 'http://aksw.org/Partner/TomTom_pl',
+                    'p' => 'http://example.org/prop_1',
+                    'o' => 'http://example.org/value_1',
+                    's_type' => 'uri',
+                    'p_type' => 'uri',
+                    'o_type' => 'uri',
+                    'o_datatype' => null,
+                    'o_lang' => null
+                )
+            ),
+            $this->fixture->extractTriplePattern(
+                '<http://aksw.org/Partner/TomTom_pl> ' .
+                '<http://example.org/prop_1> ' .
+                '<http://example.org/value_1> .'
+            )
+        );
+    }
+
     public function testExtractTriplePatternVariables()
     {
         $this->assertEquals(


### PR DESCRIPTION
Fix an issue where the method fails to extract triple patterns that
contain an underscore by adding "_" to the regular expression.

Add a unit test that reproduces the issue.
