### PR TITLE
Fix escaping of some characters in toNquads

### DIFF
--- a/src/Saft/Rdf/AbstractLiteral.php
+++ b/src/Saft/Rdf/AbstractLiteral.php
@@ -2,6 +2,8 @@
 
 namespace Saft\Rdf;
 
+use Saft\Rdf\NodeUtils;
+
 /**
  * @api
  * @since 0.1
@@ -122,7 +124,9 @@ abstract class AbstractLiteral implements Literal
      */
     public function toNQuads()
     {
-        $string = '"' . $this->getValue() . '"';
+        $nodeUtils = new NodeUtils();
+
+        $string = '"' . $nodeUtils->encodeStringLitralForNQuads($this->getValue()) . '"';
 
         if ($this->getLanguage() !== null) {
             $string .= '@' . $this->getLanguage();
@@ -132,4 +136,6 @@ abstract class AbstractLiteral implements Literal
 
         return $string;
     }
+
+
 }

--- a/src/Saft/Rdf/NodeUtils.php
+++ b/src/Saft/Rdf/NodeUtils.php
@@ -79,4 +79,15 @@ class NodeUtils
         $regEx = '/^([a-zA-Z][a-zA-Z0-9+.-]+):([^\x00-\x0f\x20\x7f<>{}|\[\]`"^\\\\])+$/';
         return (1 === preg_match($regEx, (string)$string));
     }
+
+    public function encodeStringLitralForNQuads($s)
+    {
+        $s = str_replace('\\', '\\\\', $s);
+        $s = str_replace("\t", '\t', $s);
+        $s = str_replace("\n", '\n', $s);
+        $s = str_replace("\r", '\r', $s);
+        $s = str_replace('"', '\"', $s);
+
+        return $s;
+    }
 }

--- a/src/Saft/Rdf/Test/LiteralAbstractTest.php
+++ b/src/Saft/Rdf/Test/LiteralAbstractTest.php
@@ -352,6 +352,23 @@ abstract class LiteralAbstractTest extends TestCase
         );
     }
 
+    public function testToNTEscaping()
+    {
+        // https://www.w3.org/TR/n-quads/#sec-grammar
+        // STRING_LITERAL_QUOTE ::= '"' ([^#x22#x5C#xA#xD] | ECHAR | UCHAR)* '"'
+        // #x22 = "
+        // #x5C = \
+        // #xA = LF
+        // #xD = CR
+
+        $fixture = $this->newInstance("foo \" \\ \n \r");
+
+        $this->assertEquals(
+            '"foo \" \\\\ \n \r"^^<http://www.w3.org/2001/XMLSchema#string>',
+            $fixture->toNQuads()
+        );
+    }
+
     /*
      * Tests for toString
      */


### PR DESCRIPTION
Some characters in literal strings need to be escaped in the N-Quads
format.
- add a fix that escapes '"', '\', LF and CR.
- add a helper method to the NodeUtils that contains the escaping functionality
- add a unit test

cf. issue #69 
