### PR TITLE
fix issue #89 - LiteralImpl tests and bugfix

### DIFF
--- a/src/Saft/Rdf/LiteralImpl.php
+++ b/src/Saft/Rdf/LiteralImpl.php
@@ -53,19 +53,21 @@ class LiteralImpl extends AbstractLiteral
 
         if (
             $lang !== null &&
+            $lang !== "" &&
             $datatype !== null &&
             $datatype->isNamed() &&
             $datatype->getUri() !== self::$rdfLangString
         ) {
             throw new \Exception('Language tagged Literals must have <'. self::$rdfLangString .'> datatype.');
         }
+
         if (
-            $lang === null &&
+            ($lang === null || $lang == "") &&
             $datatype !== null &&
             $datatype->isNamed() &&
             $datatype->getUri() === self::$rdfLangString
         ) {
-            throw new \Exception('No Language Tag for Literals with <'. self::$rdfLangString .'> datatype.');
+            throw new \Exception('No or empty Language Tag for Literals with <'. self::$rdfLangString .'> datatype.');
         }
 
         if ($datatype !== null) {

--- a/src/Saft/Rdf/LiteralImpl.php
+++ b/src/Saft/Rdf/LiteralImpl.php
@@ -59,6 +59,14 @@ class LiteralImpl extends AbstractLiteral
         ) {
             throw new \Exception('Language tagged Literals must have <'. self::$rdfLangString .'> datatype.');
         }
+        if (
+            $lang === null &&
+            $datatype !== null &&
+            $datatype->isNamed() &&
+            $datatype->getUri() === self::$rdfLangString
+        ) {
+            throw new \Exception('No Language Tag for Literals with <'. self::$rdfLangString .'> datatype.');
+        }
 
         if ($datatype !== null) {
             $this->datatype = $datatype;

--- a/src/Saft/Rdf/Test/LiteralAbstractTest.php
+++ b/src/Saft/Rdf/Test/LiteralAbstractTest.php
@@ -380,4 +380,22 @@ abstract class LiteralAbstractTest extends TestCase
         $this->assertTrue(is_string((string)$fixture));
         $this->assertTrue(strpos((string)$fixture, $fixture->getValue()) >= 0);
     }
+
+    /*
+     * check for literal with datatype and language
+     */
+    public function testWrongDatatypeLanguageLiteral()
+    {
+        $this->setExpectedException(\Exception::class);
+        $this->nodeFactory->createLiteral('TestLanguage', 'http://www.w3.org/2001/XMLSchema#boolean', 'de');
+    }
+
+    /*
+     * check for literal with language datatype and no language
+     */
+    public function testWrongDatatypeLiteral()
+    {
+        $this->setExpectedException(\Exception::class);
+        $this->nodeFactory->createLiteral('TestLanguage', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
+    }
 }

--- a/src/Saft/Rdf/Test/LiteralAbstractTest.php
+++ b/src/Saft/Rdf/Test/LiteralAbstractTest.php
@@ -393,9 +393,18 @@ abstract class LiteralAbstractTest extends TestCase
     /*
      * check for literal with language datatype and no language
      */
-    public function testWrongDatatypeLiteral()
+    public function testNoLanguageTagLiteral()
     {
         $this->setExpectedException(\Exception::class);
-        $this->nodeFactory->createLiteral('TestLanguage', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
+        $this->nodeFactory->createLiteral('TestNoLanguage', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString');
+    }
+
+    /*
+     * check for literal with language datatype and empty language
+     */
+    public function testEmptyLanguageTagLiteral()
+    {
+        $this->setExpectedException(\Exception::class);
+        $this->nodeFactory->createLiteral('TestEmptyLanguage', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', '');
     }
 }


### PR DESCRIPTION
* add one test for setting a datatype different from the language datatype and set a language tag
* add another test for setting language datatype but no language tag
* update LiteralImpl class to throw an Exception if language tag is not set but the language datatype is set